### PR TITLE
Feature/internship notifications

### DIFF
--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -1,6 +1,117 @@
 {% extends "base.html" %}
 
 {% block content %}
+  <div id="notifications"></div>
+  
   <h1>Welcome, {{ user.username }}!</h1>
   <p>Your dashboard overview goes here.</p>
+
+  <script>
+    let lastCheck = localStorage.getItem('lastNotificationCheck') || '0';
+    let shownNotifications = JSON.parse(localStorage.getItem('shownNotifications') || '[]');
+
+    async function checkNotifications() {
+      try {
+        const response = await fetch('/api/notifications');
+        const data = await response.json();
+        
+        if (data.new_internships && data.new_internships.length > 0) {
+          const newOnes = data.new_internships.filter(internship => 
+            !shownNotifications.includes(internship.id)
+          );
+          
+          if (newOnes.length > 0) {
+            showNotifications(newOnes);
+            shownNotifications.push(...newOnes.map(i => i.id));
+            localStorage.setItem('shownNotifications', JSON.stringify(shownNotifications));
+          }
+        }
+      } catch (error) {
+        console.log('Error checking notifications:', error);
+      }
+    }
+
+    function showNotifications(internships) {
+      const container = document.getElementById('notifications');
+      
+      internships.forEach(internship => {
+        const notification = document.createElement('div');
+        notification.className = 'notification';
+        notification.innerHTML = `
+          <div class="notification-content">
+            <strong>New Internship!</strong><br>
+            <strong>${internship.company}</strong> - ${internship.role}<br>
+            <small>${internship.location || 'Remote'}</small>
+            ${internship.link ? `<a href="${internship.link}" target="_blank">Apply</a>` : ''}
+            <button onclick="this.parentElement.parentElement.remove()">×</button>
+          </div>
+        `;
+        container.appendChild(notification);
+        
+        setTimeout(() => {
+          if (notification.parentElement) {
+            notification.remove();
+          }
+        }, 8000);
+      });
+    }
+
+    checkNotifications();
+    setInterval(checkNotifications, 30000);
+  </script>
+
+  <style>
+    #notifications {
+      position: fixed;
+      top: 20px;
+      right: 20px;
+      z-index: 1000;
+      width: 300px;
+    }
+
+    .notification {
+      background: #2196F3;
+      color: white;
+      padding: 12px;
+      margin-bottom: 10px;
+      border-radius: 4px;
+      box-shadow: 0 2px 5px rgba(0,0,0,0.2);
+      animation: slideIn 0.3s ease-out;
+    }
+
+    .notification-content {
+      position: relative;
+    }
+
+    .notification button {
+      position: absolute;
+      top: -5px;
+      right: -5px;
+      background: #f44336;
+      color: white;
+      border: none;
+      border-radius: 50%;
+      width: 20px;
+      height: 20px;
+      cursor: pointer;
+      font-size: 12px;
+    }
+
+    .notification a {
+      color: white;
+      text-decoration: underline;
+      margin-left: 10px;
+    }
+
+    @keyframes slideIn {
+      from {
+        transform: translateX(100%);
+        opacity: 0;
+      }
+      to {
+        transform: translateX(0);
+        opacity: 1;
+      }
+    }
+  </style>
 {% endblock %}


### PR DESCRIPTION
## Add Internship Notification System

 I added a notification system to the dashboard that shows users when new internships are posted from companies in their watchlist.

### What I Changed

**Backend (`app/api.py`)**
- Added `/api/notifications` endpoint that returns new internships as JSON
- Only shows internships from companies the user is watching
- Limited to 10 recent ones for performance

**Frontend (`app/templates/dashboard.html`)**
- Added notification pop-ups in the top-right corner
- They check for new internships every 30 seconds
- Notifications auto-dismiss after 8 seconds or can be manually closed
- Won't show the same notification twice

### How to Test
1. Add some companies to your watchlist
2. Wait about 30 seconds for notifications to start showing
3. Check that only internships from watchlist companies appear
4. Make sure notifications don't repeat when you refresh the page

Let me know if you see any issues or want me to change anything!